### PR TITLE
the LyCORIS model can now be used as if there were a regular LoRA model

### DIFF
--- a/scripts/batchlinks-downloader.py
+++ b/scripts/batchlinks-downloader.py
@@ -136,11 +136,13 @@ aestheticembedpath = os.path.join(script_path, "extensions/stable-diffusion-webu
 cnetpath = os.path.join(script_path, "extensions/sd-webui-controlnet/models")
 extpath = os.path.join(script_path, "extensions") #obsolete
 upscalerpath = os.path.join(script_path, "models/ESRGAN")
-lycorispath = os.path.join(addnetlorapath, "lycoris")
+#the LyCORIS model can now be used as if there were a regular LoRA model
+lycorispath = os.path.join(script_path, "models/Lora")
 
 if vladmandic:
     cnetpath = os.path.join(script_path, "models/ControlNet")
-    lycorispath = os.path.join(script_path, "models/LyCORIS")
+    #the LyCORIS model can now be used as if there were a regular LoRA model
+    lycorispath = os.path.join(script_path, "models/Lora")
 
 if cmd_opts.ckpt_dir:
     altmodelpath = cmd_opts.ckpt_dir


### PR DESCRIPTION
![image](https://github.com/etherealxx/batchlinks-webui/assets/110011280/577fddab-3771-43cf-ab5f-7d7814b50f49)
Starting from stable-diffusion-webui version 1.5.0 - version 1.6.1, the lycoris extension is no longer required, All its features have been integrated into the original LoRA extension, LyCORIS models can now be used as if there were regular LoRA models.